### PR TITLE
Cinnamox

### DIFF
--- a/cinnamox_specific/README.md
+++ b/cinnamox_specific/README.md
@@ -78,7 +78,7 @@ This forces firefox to use the GTK default Adwaita theme for rendering all websi
 
 The theme includes a helper script that creates the file with this content in the correct location. To access the tool open a terminal window and use the following command to make the script executable and launch it.
 
-`chmod +x ~/.themes/#THEMENAME/cinnamox_firefox_fix.sh && ~/.themes/#THEMENAME/cinnamon/cinnamox_firefox_fix.sh`
+`chmod +x ~/.themes/#THEMENAME/cinnamox_firefox_fix.sh && ~/.themes/#THEMENAME/cinnamox_firefox_fix.sh`
 
 ## Make your own theme using Cinnamox / Oomox
 

--- a/src/cinnamon/scss/sections/_panel.scss
+++ b/src/cinnamon/scss/sections/_panel.scss
@@ -313,7 +313,8 @@
     #appMenuIcon {
     }
 }
-.window-list-item-label {
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px;
 }
 // progress was added with cinnamon 3.6 and allows compatible applications to use the window list as a progress bar
 .window-list-item-box {

--- a/src/index.theme
+++ b/src/index.theme
@@ -7,5 +7,5 @@ Encoding=UTF-8
 [X-GNOME-Metatheme]
 Name=%OUTPUT_THEME_NAME%
 GtkTheme=%OUTPUT_THEME_NAME%
-IconTheme=%OUTPUT_THEME_NAME%
+IconTheme=Adwaita
 MetacityTheme=%OUTPUT_THEME_NAME%


### PR DESCRIPTION

* Fix typo in firefox fix instruction in readme

* Fix index.theme referencing none existent icon theme

* Cinnamon - add some padding for the window-list applet label